### PR TITLE
bump axios to 1.16 for cve fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nestjs/swagger": "^11.0.0",
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/websockets": "^11.0.0",
-        "axios": "^1.15.2",
+        "axios": "^1.16.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.4",
         "lru-cache": "^7.10.1",
@@ -3669,12 +3669,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@nestjs/swagger": "^11.0.0",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/websockets": "^11.0.0",
-    "axios": "^1.15.2",
+    "axios": "^1.16.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.4",
     "lru-cache": "^7.10.1",


### PR DESCRIPTION
| firefly-tokens-erc1155:26.6.0-r219          | CVE-2026-44492     | HIGH     | 8.6   | Trivy      | axios        | 1.16.0, 0.32.0 | axios's shouldBypassProxy does not recognize IPv4-mapped IPv6 addresses, allo... | NO     | Node.js, package-lock.json   |
| firefly-tokens-erc1155:26.6.0-r219          | CVE-2026-44494     | HIGH     | 8.7   | Trivy      | axios        | 1.16.0         | axios Vulnerable to Full Man-in-the-Middle via Prototype Pollution Gadget in ... | NO     | Node.js, package-lock.json   |
