### PR TITLE
Fix CVE-2026-5038, CVE-2026-5079: bump multer override to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8558,9 +8558,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "overrides": {
     "ws": ">=8.17.1",
-    "multer": "2.1.1",
+    "multer": "2.2.0",
     "@isaacs/brace-expansion": "5.0.1",
     "form-data": "^4.0.4",
     "path-to-regexp": "8.4.0",


### PR DESCRIPTION
Bumps the multer npm override from 2.1.1 to 2.2.0 to fix CVE-2026-5038 and CVE-2026-5079 (both HIGH).
multer is transitive (via @nestjs/platform-express); Dependabot has no alert, so the override is bumped directly.
Lockfile verified: multer 2.2.0.