### PR TITLE
fix(deps): bump nanoid to 3.3.18 for CVE-2026-67213 and CVE-2026-67214 (HIGH)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8667,9 +8667,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Bumps `nanoid` **3.3.11 -> 3.3.18** in `package-lock.json`. Lockfile-only.

## Why

The `Pipeline / CVE - Trigger` scan ([run 31374832166](https://github.com/kaleido-io/kaleido-app-cloud/actions/runs/31374832166)) reported two HIGH findings against `firefly-tokens-erc1155:26.7.1-r250`:

| CVE | Severity | Installed | Fixed in |
|---|---|---|---|
| CVE-2026-67213 | HIGH | 3.3.11 | 3.3.17, 5.1.6 |
| CVE-2026-67214 | HIGH | 3.3.11 | 3.3.16, 5.1.16 |

Both are infinite-loop denial-of-service issues. 3.3.18 is at or above both fixed versions.

`nanoid` is declared as `^3.1.31`, so the fix sits inside the existing range - no `package.json` change and no major-version risk.

## Why release-v1.3.5 and not main

`firefly-tokenconnector-erc1155.yml` in `firefly-enterprise` builds this image from `TC_REF: release-v1.3.5`. A fix on `main` never reaches the shipped image. (PR #47 on `main` is still useful for branch hygiene, but it is not the shipping fix.)

## Blocking a rebuild

The image rebuild cannot succeed until this merges. The in-build `trivy sbom` gate fails on exactly these two CVEs - see the sibling ERC20/721 rebuild [31381524836](https://github.com/kaleido-io/firefly-enterprise/actions/runs/31381524836), which died reporting `nanoid` 3.3.11. Once this is merged the image needs a rebuild + promote to clear the finding.

## Verification

- `npm ci --ignore-scripts` succeeds - validates lock consistency and the new integrity hash against the published tarball
- `npm ls nanoid` -> `nanoid@3.3.18` only, no instance below the fix
- `npm audit` -> 0 vulnerabilities
- Diff is 1 file, 3 insertions / 3 deletions